### PR TITLE
Fix compilation failure with 0.26.1-eap13

### DIFF
--- a/kotlin-coroutines-end/app/build.gradle
+++ b/kotlin-coroutines-end/app/build.gradle
@@ -43,8 +43,8 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.26.1-eap13'
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:0.26.1-eap13"
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.26.0-eap13'
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:0.26.0-eap13"
 
     implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.support:design:27.1.1'

--- a/kotlin-coroutines-repository/app/build.gradle
+++ b/kotlin-coroutines-repository/app/build.gradle
@@ -43,8 +43,8 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.26.1-eap13'
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:0.26.1-eap13"
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.26.0-eap13'
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:0.26.0-eap13"
 
 
     implementation 'com.android.support:appcompat-v7:27.1.1'

--- a/kotlin-coroutines-start/app/build.gradle
+++ b/kotlin-coroutines-start/app/build.gradle
@@ -43,8 +43,8 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.26.1-eap13'
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:0.26.1-eap13"
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.26.0-eap13'
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:0.26.0-eap13"
 
 
     implementation 'com.android.support:appcompat-v7:27.1.1'


### PR DESCRIPTION
This error occurred when starting code lab.
Probably you need to use 0.26.0-eap13.
https://github.com/Kotlin/kotlinx.coroutines/issues/591#issuecomment-423266515