### PR TITLE
Added test for the CoroutineWorker

### DIFF
--- a/kotlin-coroutines-end/app/build.gradle
+++ b/kotlin-coroutines-end/app/build.gradle
@@ -62,13 +62,18 @@ dependencies {
     implementation "androidx.room:room-runtime:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
 
-    def work_version = "1.0.0"
-    implementation "android.arch.work:work-runtime-ktx:$work_version"
+    def work_version = "2.1.0-alpha01"
+    implementation "androidx.work:work-runtime-ktx:$work_version"
 
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.1'
     androidTestImplementation 'androidx.test:rules:1.1.1'
     androidTestImplementation "com.google.truth:truth:0.42"
     androidTestImplementation "androidx.arch.core:core-testing:$lifecycle_version"
-    androidTestImplementation "android.arch.work:work-testing:$work_version"
+    androidTestImplementation "androidx.work:work-testing:$work_version"
+
+    def expresso_version = "3.1.1"
+    androidTestImplementation "androidx.test.espresso:espresso-core:$expresso_version"
+    androidTestImplementation "androidx.test.espresso:espresso-contrib:$expresso_version"
+    androidTestImplementation "androidx.test.espresso:espresso-intents:$expresso_version"
 }

--- a/kotlin-coroutines-end/app/build.gradle
+++ b/kotlin-coroutines-end/app/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     kapt "androidx.room:room-compiler:$room_version"
 
     def work_version = "1.0.0-rc01"
-    implementation "android.arch.work:work-runtime:$work_version"
+    implementation "android.arch.work:work-runtime-ktx:$work_version"
 
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.1'

--- a/kotlin-coroutines-end/app/src/main/java/com/example/android/kotlincoroutines/KotlinCoroutinesApp.kt
+++ b/kotlin-coroutines-end/app/src/main/java/com/example/android/kotlincoroutines/KotlinCoroutinesApp.kt
@@ -20,7 +20,7 @@ import android.app.Application
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy.KEEP
 import androidx.work.NetworkType.UNMETERED
-import androidx.work.PeriodicWorkRequest
+import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import com.example.android.kotlincoroutines.main.RefreshMainDataWork
 import java.util.concurrent.TimeUnit
@@ -52,8 +52,7 @@ class KotlinCoroutinesApp : Application() {
             .build()
 
         // Specify that the work should attempt to run every day
-        val work = PeriodicWorkRequest
-            .Builder(RefreshMainDataWork::class.java, 1, TimeUnit.DAYS)
+        val work = PeriodicWorkRequestBuilder<RefreshMainDataWork>(1, TimeUnit.DAYS)
             .setConstraints(constraints)
             .build()
 

--- a/kotlin-coroutines-end/app/src/main/java/com/example/android/kotlincoroutines/KotlinCoroutinesApp.kt
+++ b/kotlin-coroutines-end/app/src/main/java/com/example/android/kotlincoroutines/KotlinCoroutinesApp.kt
@@ -58,7 +58,7 @@ class KotlinCoroutinesApp : Application() {
 
         // Enqueue it work WorkManager, keeping any previously scheduled jobs for the same
         // work.
-        WorkManager.getInstance()
+        WorkManager.getInstance(this)
             .enqueueUniquePeriodicWork(RefreshMainDataWork::class.java.name, KEEP, work)
     }
 }

--- a/kotlin-coroutines-end/app/src/main/java/com/example/android/kotlincoroutines/main/RefreshMainDataWork.kt
+++ b/kotlin-coroutines-end/app/src/main/java/com/example/android/kotlincoroutines/main/RefreshMainDataWork.kt
@@ -31,10 +31,6 @@ import kotlinx.coroutines.Dispatchers
 class RefreshMainDataWork(context: Context, params: WorkerParameters) :
         CoroutineWorker(context, params) {
 
-    // CoroutineWorker defaults to Dispatchers.Default
-    // We want to execute this on Dispatchers.IO
-    override val coroutineContext = Dispatchers.IO
-
     /**
      * Refresh the title from the network using [TitleRepository]
      *

--- a/kotlin-coroutines-end/app/src/main/java/com/example/android/kotlincoroutines/main/RefreshMainDataWork.kt
+++ b/kotlin-coroutines-end/app/src/main/java/com/example/android/kotlincoroutines/main/RefreshMainDataWork.kt
@@ -27,7 +27,7 @@ import androidx.work.WorkerParameters
  * WorkManager is a library used to enqueue work that is guaranteed to execute after its constraints
  * are met. It can run work even when the app is in the background, or not running.
  */
-open class RefreshMainDataWork(context: Context, params: WorkerParameters) :
+class RefreshMainDataWork(context: Context, params: WorkerParameters) :
         CoroutineWorker(context, params) {
 
     /**

--- a/kotlin-coroutines-end/app/src/main/java/com/example/android/kotlincoroutines/main/RefreshMainDataWork.kt
+++ b/kotlin-coroutines-end/app/src/main/java/com/example/android/kotlincoroutines/main/RefreshMainDataWork.kt
@@ -17,11 +17,10 @@
 package com.example.android.kotlincoroutines.main
 
 import android.content.Context
-import androidx.annotation.WorkerThread
 import androidx.work.CoroutineWorker
 import androidx.work.Worker
 import androidx.work.WorkerParameters
-import kotlinx.coroutines.*
+import kotlinx.coroutines.Dispatchers
 
 /**
  * Worker job to refresh titles from the network while the app is in the background.

--- a/kotlin-coroutines-end/app/src/main/java/com/example/android/kotlincoroutines/main/RefreshMainDataWork.kt
+++ b/kotlin-coroutines-end/app/src/main/java/com/example/android/kotlincoroutines/main/RefreshMainDataWork.kt
@@ -24,7 +24,7 @@ import androidx.work.WorkerParameters
 import kotlinx.coroutines.*
 
 /**
- * Worker job to refresh refresh titles from the network while the app is in the background.
+ * Worker job to refresh titles from the network while the app is in the background.
  *
  * WorkManager is a library used to enqueue work that is guaranteed to execute after its constraints
  * are met. It can run work even when the app is in the background, or not running.
@@ -32,20 +32,22 @@ import kotlinx.coroutines.*
 class RefreshMainDataWork(context: Context, params: WorkerParameters) :
         CoroutineWorker(context, params) {
 
+    // CoroutineWorker defaults to Dispatchers.Default
+    // We want to execute this on Dispatchers.IO
     override val coroutineContext = Dispatchers.IO
 
     /**
      * Refresh the title from the network using [TitleRepository]
-     * 
+     *
      * WorkManager will call this method from a background thread. It may be called even
      * after our app has been terminated by the operating system, in which case [WorkManager] will
      * start just enough to run this [Worker].
      */
-    override suspend fun doWork(): Result = coroutineScope {
+    override suspend fun doWork(): Result {
         val database = getDatabase(applicationContext)
         val repository = TitleRepository(MainNetworkImpl, database.titleDao)
 
-        try {
+        return try {
             repository.refreshTitle()
             Result.success()
         } catch (error: TitleRefreshError) {


### PR DESCRIPTION
This modifies the RefreshMainDataWork class to be an open class, so that a child class can be created as a test conduit.