### PR TITLE
Implements Tests using the new features introduced in WorkManager v2.1

### DIFF
--- a/kotlin-coroutines-end/app/build.gradle
+++ b/kotlin-coroutines-end/app/build.gradle
@@ -62,12 +62,18 @@ dependencies {
     implementation "androidx.room:room-runtime:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
 
-    def work_version = "1.0.0-rc01"
-    implementation "android.arch.work:work-runtime-ktx:$work_version"
+    def work_version = "2.1.0-alpha01"
+    implementation "androidx.work:work-runtime-ktx:$work_version"
 
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.1'
     androidTestImplementation 'androidx.test:rules:1.1.1'
     androidTestImplementation "com.google.truth:truth:0.42"
     androidTestImplementation "androidx.arch.core:core-testing:$lifecycle_version"
+    androidTestImplementation "androidx.work:work-testing:$work_version"
+
+    def expresso_version = "3.1.1"
+    androidTestImplementation "androidx.test.espresso:espresso-core:$expresso_version"
+    androidTestImplementation "androidx.test.espresso:espresso-contrib:$expresso_version"
+    androidTestImplementation "androidx.test.espresso:espresso-intents:$expresso_version"
 }

--- a/kotlin-coroutines-end/app/src/androidTest/java/com/example/android/kotlincoroutines/main/RefreshMainDataWorkTest.kt
+++ b/kotlin-coroutines-end/app/src/androidTest/java/com/example/android/kotlincoroutines/main/RefreshMainDataWorkTest.kt
@@ -60,7 +60,6 @@ class RefreshMainDataWorkTest {
     }
 
     @Test
-    @Throws(Exception::class)
     fun testRefreshMainDataWork() {
         // Create request
         val request = OneTimeWorkRequestBuilder<RefreshMainDataWork>()
@@ -76,7 +75,6 @@ class RefreshMainDataWorkTest {
     }
 
     @Test
-    @Throws(Exception::class)
     fun testWithConstraints() {
         val constraints = Constraints.Builder()
                 .setRequiresCharging(true)
@@ -98,7 +96,6 @@ class RefreshMainDataWorkTest {
     }
 
     @Test
-    @Throws(Exception::class)
     fun testPeriodicWork() {
         // Create request
         val request = PeriodicWorkRequestBuilder<RefreshMainDataWork>(1, TimeUnit.DAYS)

--- a/kotlin-coroutines-end/app/src/androidTest/java/com/example/android/kotlincoroutines/main/RefreshMainDataWorkTest.kt
+++ b/kotlin-coroutines-end/app/src/androidTest/java/com/example/android/kotlincoroutines/main/RefreshMainDataWorkTest.kt
@@ -19,7 +19,6 @@ package com.example.android.kotlincoroutines.main
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.ListenableWorker.Result
-import androidx.work.WorkManager
 import androidx.work.testing.TestListenableWorkerBuilder
 import com.example.android.kotlincoroutines.util.DefaultErrorDecisionStrategy
 import com.example.android.kotlincoroutines.util.ErrorDecisionStrategy
@@ -33,13 +32,10 @@ import org.junit.runners.JUnit4
 @RunWith(JUnit4::class)
 class RefreshMainDataWorkTest {
     private lateinit var context: Context
-    private lateinit var workManager: WorkManager
 
     @Before
     fun setup() {
         context = ApplicationProvider.getApplicationContext()
-
-        workManager = WorkManager.getInstance(context)
 
         DefaultErrorDecisionStrategy.delegate =
                 object: ErrorDecisionStrategy {

--- a/kotlin-coroutines-end/app/src/androidTest/java/com/example/android/kotlincoroutines/main/RefreshMainDataWorkTest.kt
+++ b/kotlin-coroutines-end/app/src/androidTest/java/com/example/android/kotlincoroutines/main/RefreshMainDataWorkTest.kt
@@ -17,35 +17,23 @@
 package com.example.android.kotlincoroutines.main
 
 import android.content.Context
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.core.app.ApplicationProvider
-import androidx.work.Constraints
 import androidx.work.ListenableWorker.Result
-import androidx.work.NetworkType
-import androidx.work.OneTimeWorkRequestBuilder
-import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
-import androidx.work.testing.SynchronousExecutor
 import androidx.work.testing.TestListenableWorkerBuilder
 import com.example.android.kotlincoroutines.util.DefaultErrorDecisionStrategy
 import com.example.android.kotlincoroutines.util.ErrorDecisionStrategy
 import org.hamcrest.CoreMatchers.`is`
 import org.junit.Assert.assertThat
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import java.util.concurrent.Executor
-import java.util.concurrent.TimeUnit
 
 @RunWith(JUnit4::class)
 class RefreshMainDataWorkTest {
     private lateinit var context: Context
     private lateinit var workManager: WorkManager
-
-    @get:Rule
-    var instantTaskExecutorRule = InstantTaskExecutorRule()
 
     @Before
     fun setup() {
@@ -61,52 +49,12 @@ class RefreshMainDataWorkTest {
 
     @Test
     fun testRefreshMainDataWork() {
-        // Create request
-        val request = OneTimeWorkRequestBuilder<RefreshMainDataWork>()
-                .build()
-
         // Get the ListenableWorker
-        val worker = TestListenableWorkerBuilder.from(context, request).build()
+        val worker = TestListenableWorkerBuilder<RefreshMainDataWork>(context).build()
 
         // Start the work synchronously
         val result = worker.startWork().get()
 
-        assertThat(result, `is` (Result.success()))
-    }
-
-    @Test
-    fun testWithConstraints() {
-        val constraints = Constraints.Builder()
-                .setRequiresCharging(true)
-                .setRequiredNetworkType(NetworkType.UNMETERED)
-                .build()
-
-        // Create request
-        val request = OneTimeWorkRequestBuilder<RefreshMainDataWork>()
-                .setConstraints(constraints)
-                .build()
-
-        // Get the ListenableWorker
-        val worker = TestListenableWorkerBuilder.from(context, request).build()
-
-        // Start the work synchronously
-        val result = worker.startWork().get()
-
-        assertThat(result, `is` (Result.success()))
-    }
-
-    @Test
-    fun testPeriodicWork() {
-        // Create request
-        val request = PeriodicWorkRequestBuilder<RefreshMainDataWork>(1, TimeUnit.DAYS)
-                .build()
-
-        // Get the ListenableWorker
-        val worker = TestListenableWorkerBuilder.from(context, request).build()
-
-        // Start the work synchronously
-        val result = worker.startWork().get()
-
-        assertThat(result, `is` (Result.success()))
+        assertThat(result, `is`(Result.success()))
     }
 }

--- a/kotlin-coroutines-end/app/src/androidTest/java/com/example/android/kotlincoroutines/main/RefreshMainDataWorkTest.kt
+++ b/kotlin-coroutines-end/app/src/androidTest/java/com/example/android/kotlincoroutines/main/RefreshMainDataWorkTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.android.kotlincoroutines.main
+
+import android.content.Context
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.Constraints
+import androidx.work.ListenableWorker.Result
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.testing.SynchronousExecutor
+import androidx.work.testing.TestListenableWorkerBuilder
+import com.example.android.kotlincoroutines.util.DefaultErrorDecisionStrategy
+import com.example.android.kotlincoroutines.util.ErrorDecisionStrategy
+import org.hamcrest.CoreMatchers.`is`
+import org.junit.Assert.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+
+@RunWith(JUnit4::class)
+class RefreshMainDataWorkTest {
+    private lateinit var context: Context
+    private lateinit var workManager: WorkManager
+
+    @get:Rule
+    var instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+
+        workManager = WorkManager.getInstance(context)
+
+        DefaultErrorDecisionStrategy.delegate =
+                object: ErrorDecisionStrategy {
+                            override fun shouldError() = false
+                        }
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testRefreshMainDataWork() {
+        // Create request
+        val request = OneTimeWorkRequestBuilder<RefreshMainDataWork>()
+                .build()
+
+        // Get the ListenableWorker
+        val worker = TestListenableWorkerBuilder.from(context, request).build()
+
+        // Start the work synchronously
+        val result = worker.startWork().get()
+
+        assertThat(result, `is` (Result.success()))
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testWithConstraints() {
+        val constraints = Constraints.Builder()
+                .setRequiresCharging(true)
+                .setRequiredNetworkType(NetworkType.UNMETERED)
+                .build()
+
+        // Create request
+        val request = OneTimeWorkRequestBuilder<RefreshMainDataWork>()
+                .setConstraints(constraints)
+                .build()
+
+        // Get the ListenableWorker
+        val worker = TestListenableWorkerBuilder.from(context, request).build()
+
+        // Start the work synchronously
+        val result = worker.startWork().get()
+
+        assertThat(result, `is` (Result.success()))
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testPeriodicWork() {
+        // Create request
+        val request = PeriodicWorkRequestBuilder<RefreshMainDataWork>(1, TimeUnit.DAYS)
+                .build()
+
+        // Get the ListenableWorker
+        val worker = TestListenableWorkerBuilder.from(context, request).build()
+
+        // Start the work synchronously
+        val result = worker.startWork().get()
+
+        assertThat(result, `is` (Result.success()))
+    }
+}

--- a/kotlin-coroutines-end/app/src/main/java/com/example/android/kotlincoroutines/KotlinCoroutinesApp.kt
+++ b/kotlin-coroutines-end/app/src/main/java/com/example/android/kotlincoroutines/KotlinCoroutinesApp.kt
@@ -58,7 +58,7 @@ class KotlinCoroutinesApp : Application() {
 
         // Enqueue it work WorkManager, keeping any previously scheduled jobs for the same
         // work.
-        WorkManager.getInstance()
+        WorkManager.getInstance(this)
             .enqueueUniquePeriodicWork(RefreshMainDataWork::class.java.name, KEEP, work)
     }
 }

--- a/kotlin-coroutines-end/build.gradle
+++ b/kotlin-coroutines-end/build.gradle
@@ -17,13 +17,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.20'
+    ext.kotlin_version = '1.3.31'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.4.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/kotlin-coroutines-end/gradle/wrapper/gradle-wrapper.properties
+++ b/kotlin-coroutines-end/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Feb 20 09:58:00 CET 2019
+#Tue May 14 19:22:33 BST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
WorkManager v2.1 introduces `TestListenableWorkerBuilder` in the work-testing artifact that provides a nice and elegant solution to the problem to test CoroutineWorker classes.

This PR add some test for the `RefreshMainDataWork` CoroutineWorker class.