### PR TITLE
Add CacheOnSuccess with getOrAwait abstraction for use in the codelab.

### DIFF
--- a/advanced-coroutines-codelab/build.gradle
+++ b/advanced-coroutines-codelab/build.gradle
@@ -72,10 +72,6 @@ buildscript {
                 "com.github.bumptech.glide:compiler:$glide_version"
         ]
 
-        truthLibrary = [
-                "com.google.truth:truth:$truth_version"
-        ]
-
         testLibraries = [
                 "junit:junit:$junit_version",
                 // Coroutines testing
@@ -85,7 +81,9 @@ buildscript {
                 "org.mockito:mockito-core:2.23.0",
 
                 //  Architecture Components testing libraries
-                "androidx.arch.core:core-testing:$lifecycle_version"
+                "androidx.arch.core:core-testing:$lifecycle_version",
+
+                "com.google.truth:truth:$truth_version",
         ]
 
         androidTestLibraries = [

--- a/advanced-coroutines-codelab/build.gradle
+++ b/advanced-coroutines-codelab/build.gradle
@@ -72,7 +72,7 @@ buildscript {
                 "com.github.bumptech.glide:compiler:$glide_version"
         ]
 
-        librariesDebug = [
+        truthLibrary = [
                 "com.google.truth:truth:$truth_version"
         ]
 

--- a/advanced-coroutines-codelab/finished_code/build.gradle
+++ b/advanced-coroutines-codelab/finished_code/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     implementation libraries
     implementation arch_libraries
     kapt librariesKapt
-    debugImplementation truthLibrary
 
     testImplementation testLibraries
     androidTestImplementation androidTestLibraries

--- a/advanced-coroutines-codelab/finished_code/build.gradle
+++ b/advanced-coroutines-codelab/finished_code/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation libraries
     implementation arch_libraries
     kapt librariesKapt
-    debugImplementation librariesDebug
+    debugImplementation truthLibrary
 
     testImplementation testLibraries
     androidTestImplementation androidTestLibraries

--- a/advanced-coroutines-codelab/finished_code/src/main/java/com/example/android/advancedcoroutines/PlantRepository.kt
+++ b/advanced-coroutines-codelab/finished_code/src/main/java/com/example/android/advancedcoroutines/PlantRepository.kt
@@ -49,7 +49,7 @@ class PlantRepository private constructor(
 ) {
 
     // Cache for storing the custom sort order
-    private var plantsListSortOrderCache = CacheOnSuccess<List<String>>(onErrorFallback = { listOf() }) {
+    private var plantsListSortOrderCache = CacheOnSuccess(onErrorFallback = { listOf<String>() }) {
         plantService.customPlantSortOrder()
     }
 

--- a/advanced-coroutines-codelab/start/build.gradle
+++ b/advanced-coroutines-codelab/start/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     implementation libraries
     implementation arch_libraries
     kapt librariesKapt
-    debugImplementation truthLibrary
 
     testImplementation testLibraries
     androidTestImplementation androidTestLibraries

--- a/advanced-coroutines-codelab/start/build.gradle
+++ b/advanced-coroutines-codelab/start/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation libraries
     implementation arch_libraries
     kapt librariesKapt
-    debugImplementation librariesDebug
+    debugImplementation truthLibrary
 
     testImplementation testLibraries
     androidTestImplementation androidTestLibraries

--- a/advanced-coroutines-codelab/sunflower/build.gradle
+++ b/advanced-coroutines-codelab/sunflower/build.gradle
@@ -30,5 +30,6 @@ dependencies {
     implementation arch_libraries
     kapt librariesKapt
     testImplementation testLibraries
+    testImplementation truthLibrary
     androidTestImplementation androidTestLibraries
 }

--- a/advanced-coroutines-codelab/sunflower/build.gradle
+++ b/advanced-coroutines-codelab/sunflower/build.gradle
@@ -30,6 +30,5 @@ dependencies {
     implementation arch_libraries
     kapt librariesKapt
     testImplementation testLibraries
-    testImplementation truthLibrary
     androidTestImplementation androidTestLibraries
 }

--- a/advanced-coroutines-codelab/sunflower/src/main/java/com/example/android/advancedcoroutines/util/CacheOnSuccess.kt
+++ b/advanced-coroutines-codelab/sunflower/src/main/java/com/example/android/advancedcoroutines/util/CacheOnSuccess.kt
@@ -1,0 +1,121 @@
+package com.example.android.advancedcoroutines.util
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Cache the first non-error result from an async computation passed as [block].
+ *
+ * Usage:
+ *
+ * ```
+ * val cachedSuccess: CacheOnSuccess<Int> = CacheOnSuccess(onErrorFallback = { 3 }) {
+ *     delay(1_000) // compute value using coroutines
+ *     5
+ * }
+ *
+ * cachedSuccess.getOrAwait() // get the result from the cache, calling [block], or fallback on
+ *                            // exception
+ * ```
+ *
+ * @param onErrorFallback: Invoke this if [block] throws exception other than cancellation, the
+ *        result of this lambda will be returned for this call to [getOrAwait] but will not be
+ *        cached for future calls to [getOrAwait]
+ * @param block Suspending lambda that produces the cached value. The first non-exceptional value
+ *        returned by [block] will be cached, and future calls to [getOrAwait] will return the
+ *        cached value or throw a [CancellationException].
+ */
+class CacheOnSuccess<T: Any>(
+    private val onErrorFallback: (suspend () -> T)? = null,
+    private val block: suspend () -> T
+) {
+    private val mutex =  Mutex()
+
+    @Volatile
+    private var deferred: Deferred<T>? = null
+
+    /**
+     * Get the current cached value, or await the completion of [block].
+     *
+     * The result of [block] will be cached after the fist successful result, and future calls to
+     * [getOrAwait] will return the cached value.
+     *
+     * If multiple coroutines call [getOrAwait] before [block] returns, then [block] will only
+     * execute one time. If successful, they will all get the same success result. In the case of
+     * error it will not cache, and a later call to [getOrAwait] will retry the [block].
+     *
+     * If [onErrorFallback] is not null, this function will *always* call the lambda in case of
+     * error and will never cache the error result.
+     *
+     * @throws Throwable the exception thrown by [block] if [onErrorFallback] is not provided.
+     * @throws CancellationException will throw a [CancellationException] if called in a cancelled
+     *          coroutine context. This will happen even when reading the cached value.
+     */
+    suspend fun getOrAwait(): T {
+        return supervisorScope {
+            // This function is thread-safe _iff_ deferred is @Volatile and all reads and writes
+            // hold the mutex.
+
+            // only allow one coroutine to try running block at a time by using a coroutine-base
+            // Mutex
+            val currentDeferred = mutex.withLock {
+                deferred?.let { return@withLock it }
+
+                async {
+                    // Note: mutex is not held in this async block
+                    block()
+                }.also {
+                    // Note: mutex is held here
+                    deferred = it
+                }
+            }
+
+            // await the result, with our custom error handling
+            currentDeferred.safeAwait()
+        }
+    }
+
+    /**
+     * Await for a deferred, with our custom error logic.
+     *
+     * If there is an exception, clear the `deferred` field if this is still the current stored
+     * value.
+     *
+     * If the exception is cancellation, rethrow it without any changes.
+     *
+     * Otherwise, try to get a fallback value from onErrorFallback.
+     *
+     * This function is thread-safe _iff_ [deferred] is @Volatile and all reads and writes hold the
+     * mutex.
+     *
+     * @param this the deferred to wait for.
+     */
+    private suspend fun Deferred<T>.safeAwait(): T {
+        try {
+            // Note: this call to await will always throw if this coroutine is cancelled
+            return await()
+        } catch (throwable: Throwable) {
+            // If deferred still points to `this` instance of Deferred, clear it because we don't
+            // want to cache errors
+            mutex.withLock {
+                if (deferred == this) {
+                    deferred = null
+                }
+            }
+
+            // never consume cancellation
+            if (throwable is CancellationException) {
+                throw throwable
+            }
+
+            // return fallback if provided
+            onErrorFallback?.let { fallback -> return fallback() }
+
+            // if we get here the error fallback didn't provide a fallback result, so throw the
+            // exception to the caller
+            throw throwable
+        }
+    }
+
+}

--- a/advanced-coroutines-codelab/sunflower/src/main/java/com/example/android/advancedcoroutines/util/CacheOnSuccess.kt
+++ b/advanced-coroutines-codelab/sunflower/src/main/java/com/example/android/advancedcoroutines/util/CacheOnSuccess.kt
@@ -1,6 +1,9 @@
 package com.example.android.advancedcoroutines.util
 
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 

--- a/advanced-coroutines-codelab/sunflower/src/test/java/com/example/android/advancedcoroutines/util/CacheOnSuccessTest.kt
+++ b/advanced-coroutines-codelab/sunflower/src/test/java/com/example/android/advancedcoroutines/util/CacheOnSuccessTest.kt
@@ -1,10 +1,14 @@
 package com.example.android.advancedcoroutines.util
 
-import com.google.common.truth.Truth
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runBlockingTest
-import org.junit.Assert.*
+import kotlinx.coroutines.withTimeout
 import org.junit.Test
 
 class CacheOnSuccessTest {

--- a/advanced-coroutines-codelab/sunflower/src/test/java/com/example/android/advancedcoroutines/util/CacheOnSuccessTest.kt
+++ b/advanced-coroutines-codelab/sunflower/src/test/java/com/example/android/advancedcoroutines/util/CacheOnSuccessTest.kt
@@ -1,0 +1,132 @@
+package com.example.android.advancedcoroutines.util
+
+import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.*
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert.*
+import org.junit.Test
+
+class CacheOnSuccessTest {
+
+    @Test
+    fun getOrAwait_caches() = runBlockingTest {
+        var counter = 0
+        val subject = CacheOnSuccess {
+            counter++
+        }
+
+        subject.getOrAwait()
+        assertThat(subject.getOrAwait()).isEqualTo(0)
+        assertThat(counter).isEqualTo(1)
+    }
+
+    @Test
+    fun getOrAwait_reentrant_caches() = runBlockingTest {
+        val completable = CompletableDeferred<Unit>()
+        var counter = 0
+
+        val subject = CacheOnSuccess {
+            completable.await()
+            counter++
+        }
+
+        launch {
+            subject.getOrAwait()
+        }
+
+        val actual = async {
+            subject.getOrAwait()
+        }
+
+        completable.complete(Unit)
+
+        assertThat(actual.await()).isEqualTo(0)
+        assertThat(counter).isEqualTo(1)
+    }
+
+    class SomeException: Throwable()
+
+    @Test
+    fun getOrAwait_throws() = runBlockingTest {
+        val subject = CacheOnSuccess {
+            throw SomeException()
+        }
+
+        val result = kotlin.runCatching { subject.getOrAwait() }
+        assertThat(result.exceptionOrNull()).isInstanceOf(SomeException::class.java)
+    }
+
+    @Test
+    fun getOrAwait_doesntCacheExceptions() = runBlockingTest {
+        var counter = 0
+        val subject = CacheOnSuccess {
+            if(counter++ == 0) {
+                throw SomeException()
+            } else {
+                counter
+            }
+        }
+
+        kotlin.runCatching { subject.getOrAwait() }
+        assertThat(subject.getOrAwait()).isEqualTo(2)
+    }
+
+    @Test
+    fun getOrAwait_propagatesCancellation() = runBlockingTest {
+        val subject = CacheOnSuccess {
+            withTimeout(100) {
+                delay(100)
+            }
+            1
+        }
+        val result = kotlin.runCatching { subject.getOrAwait() }
+        assertThat(result.exceptionOrNull()).isInstanceOf(CancellationException::class.java)
+    }
+
+    @Test(expected = TimeoutCancellationException::class)
+    fun getOrAwait_propagatesCancellation_evenWithFallback() = runBlockingTest {
+        var called = false
+        val subject = CacheOnSuccess(onErrorFallback = { called = true; 5 }) {
+            withTimeout(100) {
+                delay(100)
+            }
+            1
+        }
+        val result = async { subject.getOrAwait() }
+
+        advanceTimeBy(100)
+        assertThat(called).isFalse()
+
+        // and throw it
+        result.await()
+    }
+
+    @Test
+    fun getOrAwait_fallsBackOnException() = runBlockingTest {
+        var calls = 0
+        val subject = CacheOnSuccess(onErrorFallback = { calls++ } ) {
+            throw SomeException()
+        }
+
+        assertThat(subject.getOrAwait()).isEqualTo(0)
+        assertThat(subject.getOrAwait()).isEqualTo(1)
+        assertThat(calls).isEqualTo(2)
+    }
+
+    @Test
+    fun getOrAwait_fallsBackOnException_withMultipleAwaits() = runBlockingTest {
+        var calls = 0
+        val subject = CacheOnSuccess(onErrorFallback = { calls++ } ) {
+            delay(100)
+            throw SomeException()
+        }
+
+        launch { subject.getOrAwait() }
+        launch { subject.getOrAwait() }
+        launch { subject.getOrAwait() }
+
+        assertThat(subject.getOrAwait()).isEqualTo(3)
+        assertThat(calls).isEqualTo(4)
+    }
+}


### PR DESCRIPTION
This cleans up the call site concurrency story and matches our recommendation to introduce appropriate abstractions.