### PR TITLE
Update theme to always use a Light theme

### DIFF
--- a/advanced-coroutines-codelab/finished_code/src/main/res/values/styles.xml
+++ b/advanced-coroutines-codelab/finished_code/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="Base.Theme.Sunflower" parent="Theme.MaterialComponents.DayNight">
+    <style name="Base.Theme.Sunflower" parent="Theme.MaterialComponents.Light">
         <item name="colorPrimary">@color/sunflower_green_500</item>
         <item name="colorOnPrimary">@color/sunflower_yellow_500</item>
         <item name="colorPrimaryDark">@color/sunflower_green_700</item>

--- a/advanced-coroutines-codelab/start/src/main/res/values/styles.xml
+++ b/advanced-coroutines-codelab/start/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="Base.Theme.Sunflower" parent="Theme.MaterialComponents.DayNight">
+    <style name="Base.Theme.Sunflower" parent="Theme.MaterialComponents.Light">
         <item name="colorPrimary">@color/sunflower_green_500</item>
         <item name="colorOnPrimary">@color/sunflower_yellow_500</item>
         <item name="colorPrimaryDark">@color/sunflower_green_700</item>


### PR DESCRIPTION
The Light theme is used even when turning on the Dark theme setting in later versions of Android.