### PR TITLE
Unlink the version of arch testing library from lifecycle lib version

### DIFF
--- a/coroutines-codelab/build.gradle
+++ b/coroutines-codelab/build.gradle
@@ -25,6 +25,7 @@ buildscript {
         // local variables (use def)
         def androidx_test_version = '1.2.0'
         def appcompat_version = '1.1.0'
+        def arch_core_test_version = '2.1.0'
         def constraint_layout_version = '1.1.3'
         def coroutines_android_version = '1.3.2'
         def expresso_version = '3.2.0'
@@ -86,7 +87,7 @@ buildscript {
                 "org.mockito:mockito-core:2.23.0",
 
                 //  Architecture Components testing libraries
-                "androidx.arch.core:core-testing:$lifecycle_version"
+                "androidx.arch.core:core-testing:$arch_core_test_version"
         ]
 
         androidTestLibraries = [
@@ -100,7 +101,7 @@ buildscript {
                 "androidx.test.espresso:espresso-intents:$expresso_version",
 
                 //  Architecture Components testing libraries
-                "androidx.arch.core:core-testing:$lifecycle_version",
+                "androidx.arch.core:core-testing:$arch_core_test_version",
                 "androidx.work:work-testing:$work_version",
 
                 // Coroutines testing


### PR DESCRIPTION
I unlinked the version of arch.core:core-testing library from lifecycle lib version. Current version of lifecycle library is 2.2.0. If we increase the version of that library in the project to the newest one, it would lead to unresolved references of classes in arch library since there is no such version for that.