### PR TITLE
Remove obsolete bintray repo from project module build gradle

### DIFF
--- a/coroutines-codelab/build.gradle
+++ b/coroutines-codelab/build.gradle
@@ -125,9 +125,6 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven {
-            url "http://dl.bintray.com/kotlin/kotlin-eap"
-        }
     }
 }
 


### PR DESCRIPTION
Fixes #153 

Remove obsolete bintray repository, due to which build fails. 
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

The WorkManager dependency, which was looked up there, is hostedin the Google Maven repository.
https://developer.android.com/jetpack/androidx/releases/work

